### PR TITLE
Add a reclassification of known deterministic

### DIFF
--- a/src/axelrod_fortran/player.py
+++ b/src/axelrod_fortran/player.py
@@ -9,6 +9,12 @@ strategies = cdll.LoadLibrary('libstrategies.so')
 actions = {0: C, 1: D}
 original_actions = {C: 0, D: 1}
 
+known_deterministic = ['K33R',  # Grudger
+                       'KTITFORTATC',  # Tit For Tat
+                       'KTF2TC',  # Tit For 2 Tats
+                       'KPAVLOVC',  # WSLS
+                       ]
+
 
 class Player(axl.Player):
 
@@ -28,6 +34,8 @@ class Player(axl.Player):
         self.original_name = original_name
         self.original_function = self.original_name
         self.game = game
+        if original_name in known_deterministic:
+            self.classifier["stochastic"] = False
 
     def __enter__(self):
         return self


### PR DESCRIPTION
This will allow for the cache to be used where possible. We should be
careful to only include strategies in this list for which we are sure.

I will add tests for this but waiting for #12 to go in so as to avoid
merge conflicts.

I'm thinking that for all the known strategies I can add a test like the
current `test_tit_for_tat` which checks classification and behaviour (as
described in #11).