### PR TITLE
Assert that K61R is axl.Champion

### DIFF
--- a/src/axelrod_fortran/strategies.py
+++ b/src/axelrod_fortran/strategies.py
@@ -157,7 +157,7 @@ characteristics = {
         'author': 'Jim Graaskamp and Ken Katzen',
         'original_rank': 6},
     'k61r': {
-        'axelrod-python_class': None,
+        'axelrod-python_class': axl.Champion,
         'stochastic': True,
         'author': 'Danny C Champion',
         'original_rank': 2},


### PR DESCRIPTION
From an analysis of the K61R code, it matches the description in the original paper and also in the docstring of axl.Champion.